### PR TITLE
Printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ rustc <fileName> -o <executableName>
 ```
 cargo build
 ```
+
+# Focus
+## Macros
+### Formatted print
+- `format` write formatted text to string.
+- `print!`: same as `format` but text is printed to the console(`io::stdout`).
+- `println!`: same as `print!` but a new line is added.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,3 @@
-use ferris_says::say;
-use std::io::{stdout, BufWriter};
-
 fn main() {
-    let stdout = stdout();
-    let message = String::from("Hello fellow Rustaceans!");
-    let width = message.chars().count();
-
-    let mut writer = BufWriter::new(stdout.lock());
-    say(&message, width, &mut writer).unwrap();
+    println!("hi there!");
 }


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to add information about macros and a simplification of the `main.rs` file by removing the use of the `ferris_says` crate.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R33): Added a new section on macros, including details about formatted print macros such as `format`, `print!`, and `println!`.

Code simplification:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1-R2): Simplified the `main` function by removing the use of the `ferris_says` crate and replacing it with a simple `println!` statement.